### PR TITLE
Add `notifyOwner` method to Redstone controllers

### DIFF
--- a/src/main/java/net/thenextlvl/redprotect/controller/AreaRedstoneController.java
+++ b/src/main/java/net/thenextlvl/redprotect/controller/AreaRedstoneController.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class AreaRedstoneController extends AbstractRedstoneController<Area> {
     private final AreaProvider areaProvider;
@@ -25,6 +26,11 @@ public class AreaRedstoneController extends AbstractRedstoneController<Area> {
     @Override
     public Optional<Player> getOwner(Area area) {
         return area.getOwner().map(plugin.getServer()::getPlayer);
+    }
+
+    @Override
+    public void notifyOwner(Area area, BiConsumer<Player, String> notification) {
+        getOwner(area).ifPresent(player -> notification.accept(player, "redstone.disabled.area"));
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/redprotect/controller/ChunkRedstoneController.java
+++ b/src/main/java/net/thenextlvl/redprotect/controller/ChunkRedstoneController.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class ChunkRedstoneController extends AbstractRedstoneController<Chunk> {
     public ChunkRedstoneController(RedProtect plugin) {
@@ -20,6 +21,10 @@ public class ChunkRedstoneController extends AbstractRedstoneController<Chunk> {
     @Override
     public Optional<Player> getOwner(Chunk region) {
         return Optional.empty();
+    }
+
+    @Override
+    public void notifyOwner(Chunk area, BiConsumer<Player, String> notification) {
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/redprotect/controller/PlotRedstoneController.java
+++ b/src/main/java/net/thenextlvl/redprotect/controller/PlotRedstoneController.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class PlotRedstoneController extends AbstractRedstoneController<Plot> {
     public PlotRedstoneController(RedProtect plugin) {
@@ -20,6 +21,11 @@ public class PlotRedstoneController extends AbstractRedstoneController<Plot> {
     @Override
     public Optional<Player> getOwner(Plot plot) {
         return Optional.ofNullable(plot.getOwner()).map(plugin.getServer()::getPlayer);
+    }
+
+    @Override
+    public void notifyOwner(Plot plot, BiConsumer<Player, String> notification) {
+        getOwner(plot).ifPresent(player -> notification.accept(player, "redstone.disabled.plot"));
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/redprotect/controller/RedstoneController.java
+++ b/src/main/java/net/thenextlvl/redprotect/controller/RedstoneController.java
@@ -30,4 +30,6 @@ public interface RedstoneController<T> {
     String toString(T region);
 
     Optional<Player> getOwner(T region);
+
+    void notifyOwner(T region, BiConsumer<Player, String> notification);
 }

--- a/src/main/resources/redprotect.properties
+++ b/src/main/resources/redprotect.properties
@@ -1,5 +1,8 @@
 prefix=<blue>RedProtect</blue> <dark_gray>»</dark_gray>
-redstone.disabled.region=<prefix> <red>Redstone got temporarily disabled on your plot <dark_gray>(<dark_red><region><dark_gray>)
-redstone.disabled=<prefix> <red>The TPS went below <dark_red><tps>\n<prefix> <red>To prevent further lag redstone is disabled now
-redstone.enabled=<prefix> <white>The TPS went above <green><tps>\n<prefix> <white>Redstone is enabled again
-redstone.warning=<prefix> <red>Detected a redstone clock at <dark_red><position>\n<prefix> <hover:show_text:'<gray>Click to teleport'><click:run_command:'/tp <x> <y> <z>'><red>Click to teleport to the position
+redstone.disabled.plot=<red><prefix> Redstone has been temporarily disabled on your plot <dark_gray>(<dark_red><region></dark_red>)</dark_gray></red>
+redstone.disabled.area=<red><prefix> Redstone has been temporarily disabled in your area <dark_gray>(<dark_red><region></dark_red>)</dark_gray></red>
+redstone.disabled=<red><prefix> The TPS went below <dark_red><tps></dark_red></red>\n\
+  <red><prefix> To prevent further lag redstone has been disabled</red>
+redstone.enabled=<gray><prefix> The TPS went above <green><tps></green></gray>\n\
+  <prefix> <white>Redstone has been enabled again
+redstone.warning=<red><prefix> Detected a redstone clock at <hover:show_text:'<gray>Click to teleport</gray>'><teleport><dark_red><world>, <x>, <y>, <z></dark_red></teleport></hover></red>

--- a/src/main/resources/redprotect_german.properties
+++ b/src/main/resources/redprotect_german.properties
@@ -1,4 +1,7 @@
-redstone.disabled.region=<prefix> <red>Redstone wurde temporär auf deinem plot <dark_gray>(<dark_red><region><dark_gray>) <red>deaktiviert
-redstone.disabled=<prefix> <red>Die TPS ist unter <dark_red><tps>\n<prefix> <red>Um weiteren Lag zu verhindern, ist Redstone jetzt deaktiviert
-redstone.enabled=<prefix> <white>Die TPS ist wieder über <green><tps>\n<prefix> <white>Redstone ist jetzt wieder aktiv
-redstone.warning=<prefix> <red>Eine redstone clock wurde bei <dark_red><x> <y> <z> <red>entdeckt\n<prefix> <hover:show_text:'<gray>Klicke zum Teleportieren'><click:run_command:'/tp <x> <y> <z>'><red>Klicke um dich zu der Position zu teleportieren
+redstone.disabled.plot=<red><prefix> Redstone wurde temporär auf deinem Plot <dark_gray>(<dark_red><region></dark_red>)</dark_gray> deaktiviert</red>
+redstone.disabled.area=<red><prefix> Redstone wurde temporär in deinem Bereich <dark_gray>(<dark_red><region></dark_red>)</dark_gray> deaktiviert</red>
+redstone.disabled=<red><prefix> Die TPS ist unter <dark_red><tps></dark_red> gesunken</red>\n\
+  <red><prefix> Um weiteren Lag zu verhindern, wurde Redstone deaktiviert</red>
+redstone.enabled=<gray><prefix> Die TPS ist über <green><tps></green> gestiegen</gray>\n\
+  <prefix> <white>Redstone wurde wieder aktiviert
+redstone.warning=<red><prefix> Eine Redstone clock wurde bei <hover:show_text:'<gray>Klicke, zum teleportieren</gray>'><teleport><dark_red><world>, <x>, <y>, <z></dark_red></teleport></hover> entdeckt</red>


### PR DESCRIPTION
Fixes #4 

Introduced `notifyOwner` in all Redstone controller implementations to notify owners about redstone-related events. Updated related messages in resource files to support new notifications. Enhanced teleport functionality in `RegionRedstoneListener`.